### PR TITLE
Handle the version in the standard go way

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,6 @@
 package main
 
-import (
-	"github.com/snowdrop/generator/pkg/server"
-	"os"
-)
+import "github.com/snowdrop/generator/pkg/server"
 
 var (
 	// VERSION is set during build
@@ -16,14 +13,5 @@ var (
 )
 
 func main() {
-
-	// Check env vars
-	v := os.Getenv("VERSION")
-	if v != "" {
-		VERSION = v
-	} else {
-		VERSION = "v0.0.0"
-	}
-
 	server.Run(VERSION, GITCOMMIT)
 }


### PR DESCRIPTION
The version and git commit are set during the build with `ldflags`