### PR TITLE
Fix issue where a previous app request could affect the next one

### DIFF
--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -33,13 +33,8 @@ func GetConfig() *Config {
 }
 
 func GetDefaultProject() *Project {
-	return p
-}
-
-//Create a new Default Project using default values
-func CreateDefaultProject() {
 	springBootBomVersion, snowdropBomVersion := getDefaultBOM()
-	p = &Project{
+	p := &Project{
 		GroupId:            "com.example",
 		ArtifactId:         "demo",
 		PackageName:        "com.example.demo",
@@ -49,7 +44,7 @@ func CreateDefaultProject() {
 		Template:           "custom",
 	}
 	p.ExtraProperties = GetConfig().ExtraProperties
-	log.Debug(">> Default Project created : ", p)
+	return p
 }
 
 func GetCorrespondingSnowDropBom(version string) string {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -49,7 +49,6 @@ func init() {
 	// - Different Snowdrop/Community BOMs
 	// - Modules and their dependencies associated / the starters
 	scaffold.ParseGeneratorConfigFile(pathConfigMap)
-	scaffold.CreateDefaultProject()
 
 	// Create the Go Templates from the Spring Boot template directory (crud, web, custom, ....)
 	scaffold.CollectVfsTemplates()


### PR DESCRIPTION
This was happening because the default project was a global variable. We
now create a new project for every request

Fixes: #31